### PR TITLE
Add Dockerfile for automatic build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.8
+
+RUN mkdir -p /go/src/tq
+WORKDIR /go/src/tq
+
+COPY . /go/src/tq
+RUN go-wrapper download
+RUN go-wrapper install
+
+CMD ["go-wrapper", "run"]

--- a/README.md
+++ b/README.md
@@ -41,14 +41,17 @@ The root of the database repo should contain a `torquilla.[toml|json|yaml]` conf
 * `migrations` list of paths where migration scripts are located
 * `definitions` list of paths where definition scripts are located
 * `extensions` if provided, only files with the specified extensions will be included
-* `version_tmpl` sql query template to record current database version
+* `template` template for output, variables available are `Script` and `Sha`
 
 Example:
 
     migrations   = [ "migrations" ]
     definitions  = [ "procedures" ]
     extensions   = [ ".sql" ]
-    version_tmpl = "INSERT INTO version_history (version_sha) VALUES (%s)"
+    template    = """
+      {{.Script}}
+      -- Insert new version number
+      INSERT INTO version_history (version_sha) VALUES ('{{.Sha}}');"""
 
 File selection and ordering
 ---------------------------


### PR DESCRIPTION
@pshangov I have added a Dockerfile as if we dockerize this we can use it in Bitbucket pipelines to automatically build our database Docker images. 

We can connect this repo to Docker Hub to automatically build a public Docker image for torquilla when commits are pushed to github
https://docs.docker.com/docker-hub/builds/